### PR TITLE
Duration gap

### DIFF
--- a/plan.go
+++ b/plan.go
@@ -35,7 +35,7 @@ func (p *Plan) Run() {
 		wg.Add(1)
 		go func(t *Thread) {
 			defer wg.Done()
-			fmt.Printf("Running %d threads on route %s\n", t.Count, t.Route)
+			fmt.Printf("Running %d threads sending a new request each %dms during %dms on route %s\n", t.Count, t.Gap, t.Duration, t.Route)
 			t.Run(p.Host, p.Port)
 		}(thread)
 	}

--- a/thread.go
+++ b/thread.go
@@ -53,7 +53,7 @@ func (t *Thread) Run(host string, port int) {
 		wg.Add(1)
 		go func(i int) {
 			defer wg.Done()
-			clients[i].Open(host, port)
+			clients[i].New(host, port)
 		}(i)
 	}
 	wg.Wait()
@@ -73,8 +73,9 @@ func (t *Thread) Run(host string, port int) {
 			}(i)
 		}
 		time.Sleep(time.Duration(t.Gap) * time.Millisecond)
-		wg.Wait()
 	}
+	fmt.Println("Done. Waiting for remaining connections to finish... This can take a while according to your web server.")
+	wg.Wait()
 	
 	for i, _ := range clients {
 		clients[i].Close()


### PR DESCRIPTION
Issue #2 

Allow to send `count` requests each `gap` ms during `duration` ms. Each request create a new socket to avoid socket reading errors in case the socket is already receiving data while sending new requests.
